### PR TITLE
clarify agent instructions and remove inaccurate RAG reference

### DIFF
--- a/Instructions/Labs/01-exercise-template.md
+++ b/Instructions/Labs/01-exercise-template.md
@@ -90,14 +90,16 @@ In this task, you will learn how to implement RAG using a data source for your o
 In this task you will create the custom agent and test the agent.
 
 1. Open **Visual Studio Code**.
-2. In the right hand side of the visual studio code window select **View** in the ribbon above > **Extensions** > search for **Microsoft 356 Agents Toolkit** > select **Update** > **Restart Extensions** > select **Create a New Agent/App** > in the dropdown select **Custom Engine Agent**  > **Basic Custom Engine Agent** > **JavaScript** > **Azure OpenAI** . **Note** you may have to close out of VS code and reopen after updating the toolkit.
+2. In the right hand side of the visual studio code window select **View** in the ribbon above > **Extensions** > search for **Microsoft 356 Agents Toolkit** > select **Update** > **Restart Extensions** > select **Create a New Agent/App** > in the dropdown select **Custom Engine Agent**  > **Basic Custom Engine Agent** > **Azure OpenAI** . 
+
+**Note** you may have to close out of VS code and reopen after updating the toolkit.
 3. In the blank box at the top of the screen, first enter :
 
    a. **API Key** from the previous task > **Enter**.
 
    b. **Endpoint** from the previous task > **Enter**.
 
-   c. For **Azure Open AI deployment name** type in **gpt-4** > **Enter** > **JavaScript**. 
+   c. For **Azure Open AI deployment name** type in **gpt-4o** > **Enter** > **JavaScript**. 
 
    d. For **Choose the folder where your project room folder will be located**, select **Default folder**.
 
@@ -143,7 +145,7 @@ In this task you will create the custom agent and test the agent.
 9. Navigate back to the VS Code window for your app. Select the **Debug** button dropdown and select **Debug in Teams (Edge)** then press **F5** or the gren play button.
 10. A new window in your Edge browser will open. You may or may not be prompted to sign in. Use the login information provided to sign in. After successfully signing in, close the window.
 11. There should be a window with the title of your newly created app. Select **Add** > **Open**.
-12. Congrats! You can now ask the agent any question pertaining to the RAG data files.
+12. Congrats! You can now test your agent by asking questions.
 13. **Note:** For Learners completing this lab on their own environment, this agent was made for educational purposes using your own subscription, users should proceed with deleting the agent after completion of this lab. To delete a custom agent in Microsoft Teams, you can:
 - Select the agent you want to delete, then choose the **More options icon (…)** and select **Delete**.
 - Remove the agent from a chat by selecting the ellipses in the thread and choosing **Manage Apps**.


### PR DESCRIPTION
Fixes #4
## Summary
This pull request updates the lab instructions to clarify why the agent in Lab MS‑4015 does not retrieve information from RAG data files, even when learners upload documents to Azure AI Search and create an index.

In the current lab environment:

- The Azure Foundry Chat Playground handles RAG **automatically** (file upload, chunking, embeddings, vector retrieval, and context injection).
- The agent implementation used in **debug/deployed mode** contains **no code** to connect to Azure AI Search or perform retrieval.
- As a result, the agent does not query the index and cannot answer questions based on uploaded documents.
- Additionally, the lab provider sandbox has a vector index quota of **0 bytes**, preventing embeddings from being generated — even if RAG code were added.

## Impact on learners
Learners may expect the agent to respond using RAG files because the Playground demo works correctly.  
However, the behavior differs:

- **Playground:** RAG is automatic and functional  
- **Agent (debug/deployed):** RAG is not implemented  

## Proposed improvement
Removed the incorrect instruction in Task 3, Step 6 that suggested the agent could respond using RAG data files.
 This is incorrect because the agent template does **not** integrate with Azure AI Search or perform vector retrieval.
 
## Additional improvements
To ensure accuracy and prevent learners from following incorrect steps, the following adjustments were made:

1. **Corrected Azure OpenAI deployment name**  
   The previous value (`gpt‑4*`) did not match the deployment created earlier in the lab and could cause failures when configuring the agent.

2. **Corrected the step ordering in the Microsoft 365 Agents Toolkit instructions**  
   The updated sequence now reflects the actual UI flow, avoiding confusion during the agent creation process.

These changes improve clarity, align the instructions with actual agent capabilities, and prevent learners from troubleshooting a feature that is not implemented.

``
